### PR TITLE
Avoid multiple definition linker errors when compiling without -DBACKTRACE

### DIFF
--- a/bc.hpp
+++ b/bc.hpp
@@ -59,7 +59,7 @@ static void print_trace() {
   exit(1);
 }
 #else
-void print_trace() {
+static void print_trace() {
   printf("Compile with -DBACKTRACE to see a backtrace\n");
 }
 #endif


### PR DESCRIPTION
This can be tested by attempting to link multiple compilation units without specifying -DBACKTRACE.